### PR TITLE
Updating conventional-changelog to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sketch7/ssv-core"
   },
   "devDependencies": {
-    "conventional-changelog": "^0.5.3",
+    "conventional-changelog": "^1.1.0",
     "del": "^2.2.0",
     "es6-module-loader": "^0.17.10",
     "gulp": "^3.9.0",


### PR DESCRIPTION
Please update [conventional-changelog](https://npmjs.org/package/conventional-changelog) to version 1.1.0.

If this passes your tests you can merge it in.  If not please use this branch for changes.
- [`600d411`](https://github.com/ajoslin/conventional-changelog/commit/600d411569271467389c3cbe71f7f657980e89a1) `chore(release): 1.1.0`
- [`3894e03`](https://github.com/ajoslin/conventional-changelog/commit/3894e039aed46bc97baa9d9712af1368d1e40580) `docs(CHANGELOG): 1.1.0`
- [`9591280`](https://github.com/ajoslin/conventional-changelog/commit/9591280a8d09220aced3383abe3bc7ecbb34b503) `chore(release): 1.0.2`
- [`49ede9d`](https://github.com/ajoslin/conventional-changelog/commit/49ede9dd736e00c3dcda211c6f5f30f3c27b19ae) `docs(CHANGELOG): 1.0.2`
- [`50ebb4b`](https://github.com/ajoslin/conventional-changelog/commit/50ebb4b48a38587ec469c03c23dc7a5c644b9aac) `chore(bump): deps`
- [`beef421`](https://github.com/ajoslin/conventional-changelog/commit/beef421f56939190a4ca30c28788eda1b3f9480d) `chore(release): 1.0.1`
- [`c2f7b25`](https://github.com/ajoslin/conventional-changelog/commit/c2f7b25c1ff548bbd0bb281e5c9522ddbaa7e369) `docs(CHANGELOG): 1.0.1`
- [`8da7df5`](https://github.com/ajoslin/conventional-changelog/commit/8da7df54a760aadb413644fb044784ccbdeda9c3) `chore(deps): bump conventional-changelog-angular`
- [`c8e90ab`](https://github.com/ajoslin/conventional-changelog/commit/c8e90ab7fddd0b98855913e73fc12f9dc9dc81b1) `chore(release): 1.0.0`
- [`0d2c22f`](https://github.com/ajoslin/conventional-changelog/commit/0d2c22f50553da4280e027b087f64fe4f0ff48e9) `docs(CHANGELOG): 1.0.0`
- [`929cc47`](https://github.com/ajoslin/conventional-changelog/commit/929cc475ce49a213193a67e04a21ff09624e78c3) `chore(deps): bump`
- [`1542cc7`](https://github.com/ajoslin/conventional-changelog/commit/1542cc7f720e59bd24176230a97aa6c9e040d178) `docs(README): clarify `options.preset``
- [`65a9f4b`](https://github.com/ajoslin/conventional-changelog/commit/65a9f4bfcfb2621fbcc9eed8876dd22e96a55ed0) `fix(bin): no cli anymore`
- [`e05ef37`](https://github.com/ajoslin/conventional-changelog/commit/e05ef378c2e30c0428943e449c8b4c1dd87baa86) `docs(wrapper): link to the doc in core`
- [`0289ffe`](https://github.com/ajoslin/conventional-changelog/commit/0289ffe2884fd207f4c41e7ac9860037be93cef3) `test: tweak`

See the full [change log](https://github.com/ajoslin/conventional-changelog/compare/d79ce243223260b153699b99de0503698546ea63...600d411569271467389c3cbe71f7f657980e89a1) for everything that changed in this release.
